### PR TITLE
Add Heine Bautz portfolio redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Codex Apple Design</title>
+    <title>Heine Bautz - AI Developer</title>
     <style>
         :root {
             --bg-start: #1e1e1e;
@@ -11,29 +11,25 @@
             --accent: #5af5ff;
             --glass-color: rgba(255,255,255,0.1);
         }
-
         * {
             box-sizing: border-box;
-        }
-
-        html, body {
             margin: 0;
             padding: 0;
+        }
+        html, body {
             height: 100%;
             overflow: hidden;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-            color: white;
+            color: #fff;
         }
-
         body {
             background: radial-gradient(circle at top left, var(--bg-start), var(--bg-end));
+            animation: bgshift 20s linear infinite;
             display: flex;
             align-items: center;
             justify-content: center;
-            perspective: 1000px;
-            overflow: hidden;
+            perspective: 1200px;
         }
-
         #mesh {
             position: absolute;
             top: 0;
@@ -42,100 +38,151 @@
             height: 100%;
             z-index: -1;
         }
-
         .glass-card {
-            backdrop-filter: blur(20px) saturate(150%);
-            -webkit-backdrop-filter: blur(20px) saturate(150%);
+            position: relative;
+            backdrop-filter: blur(25px) saturate(160%);
+            -webkit-backdrop-filter: blur(25px) saturate(160%);
             background-color: var(--glass-color);
             border-radius: 20px;
-            padding: 4rem;
+            padding: 4rem 6rem;
             text-align: center;
-            box-shadow: 0 25px 50px rgba(0,0,0,0.2);
+            box-shadow: 0 40px 60px rgba(0,0,0,0.25);
+            transition: transform 0.3s ease;
             transform-style: preserve-3d;
-            animation: float 8s ease-in-out infinite;
         }
-
         h1 {
-            font-size: 3rem;
-            margin: 0 0 1rem;
+            font-size: 4rem;
+            margin-bottom: 1rem;
         }
-
         p {
-            margin: 0;
-            font-size: 1.25rem;
+            font-size: 1.5rem;
             opacity: 0.85;
         }
-
-        @keyframes float {
-            0%, 100% { transform: rotateY(-10deg) translateZ(30px); }
-            50% { transform: rotateY(10deg) translateZ(50px); }
+        .links {
+            margin-top: 1.5rem;
+        }
+        .links a {
+            display: inline-block;
+            margin: 0 0.5rem;
+            padding: 0.75rem 1.5rem;
+            border: 1px solid var(--accent);
+            border-radius: 999px;
+            color: var(--accent);
+            text-decoration: none;
+            transition: background 0.3s, color 0.3s;
+        }
+        .links a:hover {
+            background: var(--accent);
+            color: #000;
+        }
+        @keyframes bgshift {
+            0% { filter: hue-rotate(0deg); }
+            100% { filter: hue-rotate(360deg); }
         }
     </style>
 </head>
 <body>
     <canvas id="mesh"></canvas>
-    <div class="glass-card">
-        <h1>Codex</h1>
-        <p>Impossibly Beautiful</p>
+    <div class="glass-card" id="card">
+        <h1>Heine Bautz</h1>
+        <p id="typed"></p>
+        <div class="links">
+            <a href="mailto:hire@heinebautz.com">Hire Me</a>
+            <a href="https://github.com/HeineBautz" target="_blank">GitHub</a>
+        </div>
     </div>
-    <script>
-        const canvas = document.getElementById('mesh');
-        const ctx = canvas.getContext('2d');
-        const stars = [];
-        const starCount = 200;
-        const maxDepth = 32;
+<script>
+const canvas = document.getElementById('mesh');
+const ctx = canvas.getContext('2d');
+let width, height, starCount;
+const stars = [];
+const maxDepth = 32;
 
-        function resize() {
-            canvas.width = window.innerWidth;
-            canvas.height = window.innerHeight;
+function resize() {
+    width = canvas.width = window.innerWidth;
+    height = canvas.height = window.innerHeight;
+    starCount = Math.min(Math.floor(width * height / 800), 1000);
+    initStars();
+}
+
+function initStars() {
+    stars.length = 0;
+    for (let i = 0; i < starCount; i++) {
+        stars.push({
+            x: Math.random() * width - width / 2,
+            y: Math.random() * height - height / 2,
+            z: Math.random() * maxDepth
+        });
+    }
+}
+
+function update() {
+    for (const star of stars) {
+        star.z -= 0.2;
+        if (star.z <= 0) star.z = maxDepth;
+    }
+}
+
+function draw() {
+    ctx.clearRect(0, 0, width, height);
+    const hue = (Date.now() / 50) % 360;
+    ctx.fillStyle = `hsla(${hue},60%,50%,0.1)`;
+    ctx.fillRect(0, 0, width, height);
+    for (const star of stars) {
+        const k = 128 / star.z;
+        const x = star.x * k + width / 2;
+        const y = star.y * k + height / 2;
+        if (x >= 0 && x <= width && y >= 0 && y <= height) {
+            const size = (1 - star.z / maxDepth) * 3;
+            ctx.fillStyle = `hsl(${hue},80%,80%)`;
+            ctx.beginPath();
+            ctx.arc(x, y, size, 0, Math.PI * 2);
+            ctx.fill();
         }
+    }
+}
 
-        function initStars() {
-            for (let i = 0; i < starCount; i++) {
-                stars[i] = {
-                    x: Math.random() * canvas.width - canvas.width / 2,
-                    y: Math.random() * canvas.height - canvas.height / 2,
-                    z: Math.random() * maxDepth
-                };
-            }
+function frame() {
+    update();
+    draw();
+    requestAnimationFrame(frame);
+}
+
+const card = document.getElementById('card');
+function handleMove(e) {
+    const x = (e.clientX / width - 0.5) * 30;
+    const y = (e.clientY / height - 0.5) * 30;
+    card.style.transform = `rotateX(${-y}deg) rotateY(${x}deg)`;
+}
+
+window.addEventListener('mousemove', handleMove);
+window.addEventListener('resize', resize);
+resize();
+frame();
+const typed = document.getElementById("typed");
+const phrases = ["AI Developer", "Machine Learning Specialist", "Available for Hire"];
+let line = 0, indexChar = 0, forward = true;
+function typeLoop(){
+    typed.textContent = phrases[line].slice(0, indexChar);
+    if(forward){
+        if(indexChar < phrases[line].length){
+            indexChar++;
+        } else {
+            forward = false;
+            setTimeout(typeLoop, 1000);
+            return;
         }
-
-        function update() {
-            for (let i = 0; i < starCount; i++) {
-                stars[i].z -= 0.2;
-                if (stars[i].z <= 0) {
-                    stars[i].z = maxDepth;
-                }
-            }
+    } else {
+        if(indexChar > 0){
+            indexChar--;
+        } else {
+            forward = true;
+            line = (line + 1) % phrases.length;
         }
-
-        function draw() {
-            ctx.fillStyle = 'black';
-            ctx.fillRect(0, 0, canvas.width, canvas.height);
-            for (let i = 0; i < starCount; i++) {
-                const k = 128 / stars[i].z;
-                const x = stars[i].x * k + canvas.width / 2;
-                const y = stars[i].y * k + canvas.height / 2;
-                if (x >= 0 && x <= canvas.width && y >= 0 && y <= canvas.height) {
-                    const size = (1 - stars[i].z / maxDepth) * 3;
-                    ctx.fillStyle = 'white';
-                    ctx.beginPath();
-                    ctx.arc(x, y, size, 0, Math.PI * 2);
-                    ctx.fill();
-                }
-            }
-        }
-
-        function frame() {
-            update();
-            draw();
-            requestAnimationFrame(frame);
-        }
-
-        window.addEventListener('resize', resize);
-        resize();
-        initStars();
-        frame();
-    </script>
+    }
+    setTimeout(typeLoop, 120);
+}
+window.addEventListener("DOMContentLoaded", typeLoop);
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- transform page into Heine Bautz AI portfolio
- add call‑to‑action links
- implement animated typed tagline

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`
